### PR TITLE
chore(): make it PHP 8.4 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Requirements
 
- * php: ^7.0|^8.0
+ * php: ^8.0
 
 ## Suggests
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Converter/IteratableToNodeConverter.php
+++ b/src/Converter/IteratableToNodeConverter.php
@@ -11,21 +11,14 @@ use Saxulum\ElasticSearchQueryBuilder\Node\ObjectNode;
 
 final class IteratableToNodeConverter implements IteratableToNodeConverterInterface
 {
-    private ScalarToNodeConverterInterface $scalarToNodeConverter;
-
-    public function __construct(ScalarToNodeConverterInterface $scalarToNodeConverter)
+    public function __construct(private ScalarToNodeConverterInterface $scalarToNodeConverter)
     {
-        $this->scalarToNodeConverter = $scalarToNodeConverter;
     }
 
     /**
-     * @param mixed  $data
-     * @param string $path
-     * @param bool   $allowSerializeEmpty
      * @return ArrayNode|ObjectNode
-     * @throws \InvalidArgumentException
      */
-    public function convert($data, string $path = '', bool $allowSerializeEmpty = false): AbstractParentNode
+    public function convert(mixed $data, string $path = '', bool $allowSerializeEmpty = false): AbstractParentNode
     {
         if (!is_iterable($data)) {
             throw new \InvalidArgumentException('Parameters need to be iterable.');
@@ -87,14 +80,7 @@ final class IteratableToNodeConverter implements IteratableToNodeConverterInterf
         return $parentNode;
     }
 
-    /**
-     * @param mixed  $value
-     * @param string $path
-     * @param bool   $allowSerializeEmpty
-     *
-     * @return AbstractNode
-     */
-    private function getNode($value, string $path, bool $allowSerializeEmpty): AbstractNode
+    private function getNode(mixed $value, string $path, bool $allowSerializeEmpty): AbstractNode
     {
         if (is_iterable($value)) {
             return $this->convert($value, $path, $allowSerializeEmpty);

--- a/src/Converter/IteratableToNodeConverterInterface.php
+++ b/src/Converter/IteratableToNodeConverterInterface.php
@@ -9,14 +9,10 @@ use Saxulum\ElasticSearchQueryBuilder\Node\AbstractParentNode;
 interface IteratableToNodeConverterInterface
 {
     /**
-     * @param mixed $data
-     *
-     * @return AbstractParentNode
-     *
      * @throws \InvalidArgumentException
      *
      * @todo add $path to next major version
      * @todo add $allowSerializeEmpty to next major version
      */
-    public function convert($data): AbstractParentNode;
+    public function convert(mixed $data): AbstractParentNode;
 }

--- a/src/Converter/ScalarToNodeConverter.php
+++ b/src/Converter/ScalarToNodeConverter.php
@@ -21,16 +21,7 @@ final class ScalarToNodeConverter implements ScalarToNodeConverterInterface
         'string' => StringNode::class,
     ];
 
-    /**
-     * @param bool|float|int|null|string|object $value
-     * @param string                            $path
-     * @param bool                              $allowSerializeEmpty
-     *
-     * @return AbstractNode
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function convert($value, string $path = '', bool $allowSerializeEmpty = false): AbstractNode
+    public function convert(mixed $value, string $path = '', bool $allowSerializeEmpty = false): AbstractNode
     {
         if (null === $value) {
             return NullNode::create();

--- a/src/Converter/ScalarToNodeConverterInterface.php
+++ b/src/Converter/ScalarToNodeConverterInterface.php
@@ -9,14 +9,10 @@ use Saxulum\ElasticSearchQueryBuilder\Node\AbstractNode;
 interface ScalarToNodeConverterInterface
 {
     /**
-     * @param bool|float|int|null|string $value
-     * @param string                     $path
-     *
-     * @return AbstractNode
-     *
+     * @param bool|float|int|string|null $value
      * @throws \InvalidArgumentException
      *
      * @todo add $allowSerializeEmpty to next major version
      */
-    public function convert($value, string $path = ''): AbstractNode;
+    public function convert(mixed $value, string $path = ''): AbstractNode;
 }

--- a/src/Node/BoolNode.php
+++ b/src/Node/BoolNode.php
@@ -8,7 +8,7 @@ final class BoolNode extends AbstractNode
 {
     private ?bool $value;
 
-    public static function create(bool $value = null, bool $allowSerializeEmpty = false): BoolNode
+    public static function create(?bool $value = null, bool $allowSerializeEmpty = false): BoolNode
     {
         $node = new self();
         $node->value = $value;

--- a/src/Node/FloatNode.php
+++ b/src/Node/FloatNode.php
@@ -8,7 +8,7 @@ final class FloatNode extends AbstractNode
 {
     private ?float $value;
 
-    public static function create(float $value = null, bool $allowSerializeEmpty = false): FloatNode
+    public static function create(?float $value = null, bool $allowSerializeEmpty = false): FloatNode
     {
         $node = new self();
         $node->value = $value;

--- a/src/Node/IntNode.php
+++ b/src/Node/IntNode.php
@@ -8,7 +8,7 @@ final class IntNode extends AbstractNode
 {
     private ?int $value;
 
-    public static function create(int $value = null, bool $allowSerializeEmpty = false): IntNode
+    public static function create(?int $value = null, bool $allowSerializeEmpty = false): IntNode
     {
         $node = new self();
         $node->value = $value;

--- a/src/Node/StringNode.php
+++ b/src/Node/StringNode.php
@@ -8,7 +8,7 @@ final class StringNode extends AbstractNode
 {
     private ?string $value;
 
-    public static function create(string $value = null, bool $allowSerializeEmpty = false): StringNode
+    public static function create(?string $value = null, bool $allowSerializeEmpty = false): StringNode
     {
         $node = new self();
         $node->value = $value;


### PR DESCRIPTION
- use PHP 8.0 style to avoid deprecations when using with PHP 8.4 (nullable typed properties with default null value, mixed, constructor promoted properties ...)